### PR TITLE
Fix testcases with v0.14 compat layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 rvm:
- - 1.9.2
- - 1.9.3
+  - 2.1
+  - 2.2
+  - 2.3.4
+  - 2.4.1
 
-script: bundle exec rake test
+before_install:
+  - gem update bundler
+
+script:
+  - bundle exec rake test

--- a/fluent-plugin-resque.gemspec
+++ b/fluent-plugin-resque.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"
+  gem.add_development_dependency "test-unit", ">= 3.2.0"
+  gem.add_development_dependency "test-unit-rr", ">= 1.0.0"
 end

--- a/test/plugin/out_resque.rb
+++ b/test/plugin/out_resque.rb
@@ -28,18 +28,18 @@ class ResqueOutputTest < Test::Unit::TestCase
 
   def test_write
     d = create_driver
-    time = Time.at(Time.now.to_i).utc
+    time = Time.at(Time.now.to_i).utc.to_i
     d.emit({'a' => 1, "class" => "WorkerTest"}, time)
     d.emit({'b' => 2, "class" => "WorkerTest"}, time)
-    check_enqueue("test_queue", "WorkerTest", {"a" => 1, "time" => time.strftime("%y-%m-%d %H:%M:%S")})
-    check_enqueue("test_queue", "WorkerTest", {"b" => 2, "time" => time.strftime("%y-%m-%d %H:%M:%S")})
+    check_enqueue("test_queue", "WorkerTest", {"a" => 1, "time" => Time.at(time).utc.strftime("%y-%m-%d %H:%M:%S")})
+    check_enqueue("test_queue", "WorkerTest", {"b" => 2, "time" => Time.at(time).utc.strftime("%y-%m-%d %H:%M:%S")})
     d.run
     assert_equal true, true
   end
 
   def test_write_except_time_key
     d = create_driver(CONFIG + "\ninclude_time_key false")
-    time = Time.at(Time.now.to_i).utc
+    time = Time.at(Time.now.to_i).utc.to_i
     d.emit({'a' => 1, 'class' => 'WorkerTest'}, time)
     check_enqueue("test_queue", "WorkerTest", {"a" => 1})
     d.run
@@ -47,17 +47,17 @@ class ResqueOutputTest < Test::Unit::TestCase
 
   def test_write_include_tag_key
     d = create_driver(CONFIG + "\ninclude_tag_key true")
-    time = Time.at(Time.now.to_i).utc
+    time = Time.at(Time.now.to_i).utc.to_i
     d.emit({'a' => 1, 'class' => 'WorkerTest'}, time)
-    check_enqueue("test_queue", "WorkerTest", {"a" => 1, "tag" => 'test', "time" => time.strftime("%y-%m-%d %H:%M:%S")})
+    check_enqueue("test_queue", "WorkerTest", {"a" => 1, "tag" => 'test', "time" => Time.at(time).utc.strftime("%y-%m-%d %H:%M:%S")})
     d.run
   end
 
   def test_write_change_worker_class_name_tag
     d = create_driver(CONFIG + "\nworker_class_name_tag klass")
-    time = Time.at(Time.now.to_i).utc
+    time = Time.at(Time.now.to_i).utc.to_i
     d.emit({'a' => 1, 'klass' => 'WorkerTest::Test'}, time)
-    check_enqueue("test_queue", "WorkerTest::Test", {"a" => 1, "time" => time.strftime("%y-%m-%d %H:%M:%S")})
+    check_enqueue("test_queue", "WorkerTest::Test", {"a" => 1, "time" => Time.at(time).utc.strftime("%y-%m-%d %H:%M:%S")})
     d.run
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,4 +17,5 @@ if ENV['SIMPLE_COV']
 end
 
 require 'test/unit'
+require 'test/unit/rr'
 require 'fluent/test'


### PR DESCRIPTION
At starting to use v0.14 API migration, we should make all test cases green.

With v0.14 Compatible later, time argument now permits `Integer` or `EventTime` type.
So we should use unix time stamp(Integer) here.